### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/PetroRavlinko/concordion-mockserver-extension.png?label=ready&title=Ready)](https://waffle.io/PetroRavlinko/concordion-mockserver-extension)
 [![Build Status](https://travis-ci.org/PetroRavlinko/concordion-mockserver-extension.svg?branch=master)](https://travis-ci.org/PetroRavlinko/concordion-mockserver-extension)
 [ ![Download](https://api.bintray.com/packages/ravlinko/snapshots/concordion-mockserver-extension/images/download.svg) ](https://bintray.com/ravlinko/snapshots/concordion-mockserver-extension/_latestVersion)
 [![Apache License 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/PetroRavlinko/concordion-mockserver-extension

This was requested by a real person (user PetroRavlinko) on waffle.io, we're not trying to spam you.